### PR TITLE
Fix ActiveAdmin::Inputs::Filters::DateRangeInput cover last day

### DIFF
--- a/lib/active_admin/inputs/filters/date_range_input.rb
+++ b/lib/active_admin/inputs/filters/date_range_input.rb
@@ -15,12 +15,12 @@ module ActiveAdmin
         end
 
         def gt_input_name
-          "#{method}_gteq"
+          "#{method}_gteq_date"
         end
         alias :input_name :gt_input_name
 
         def lt_input_name
-          "#{method}_lteq"
+          "#{method}_lteq_date"
         end
 
         def input_html_options(input_name = gt_input_name)

--- a/lib/ransack_ext.rb
+++ b/lib/ransack_ext.rb
@@ -9,4 +9,12 @@ Ransack.configure do |config|
   {'equals'=>'eq', 'greater_than'=>'gt', 'less_than'=>'lt'}.each do |old,current|
     config.add_predicate old, arel_predicate: current
   end
+  
+  config.add_predicate 'gteq_date',
+    arel_predicate: 'gteq',
+    formatter: ->(v) { v.beginning_of_day }
+  
+  config.add_predicate 'lteq_date',
+    arel_predicate: 'lt',
+    formatter: ->(v) { v + 1.day }
 end

--- a/spec/unit/filters/filter_form_builder_spec.rb
+++ b/spec/unit/filters/filter_form_builder_spec.rb
@@ -156,13 +156,13 @@ describe ActiveAdmin::Filters::ViewHelper do
     let(:body) { Capybara.string(filter :created_at) }
 
     it "should generate a date greater than" do
-      expect(body).to have_selector("input.datepicker[name='q[created_at_gteq]']")
+      expect(body).to have_selector("input.datepicker[name='q[created_at_gteq_date]']")
     end
     it "should generate a seperator" do
       expect(body).to have_selector("span.seperator")
     end
     it "should generate a date less than" do
-      expect(body).to have_selector("input.datepicker[name='q[created_at_lteq]']")
+      expect(body).to have_selector("input.datepicker[name='q[created_at_lteq_date]']")
     end
   end
 


### PR DESCRIPTION
Monkey patch from this pr. https://github.com/activeadmin/activeadmin/pull/4504/commits. Because we can't update to latest version

Signed-off-by: Dhurba Baral <dhurba87@gmail.com>